### PR TITLE
Fix Scenario: All meetings are displayed on home page when it is opened - no hardcode

### DIFF
--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeGivenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeGivenSteps.java
@@ -1,0 +1,22 @@
+package org.fundacionjala.automation.scenario.steps.tablet.home;
+
+import org.fundacionjala.automation.framework.utils.api.managers.MeetingAPIManager;
+import org.fundacionjala.automation.framework.utils.api.objects.admin.Meeting;
+import org.fundacionjala.automation.framework.utils.common.PropertiesReader;
+import org.fundacionjala.automation.framework.utils.common.RMGenerator;
+
+import cucumber.api.java.en.Given;
+
+public class HomeGivenSteps {
+
+    @Given("^I have a meeting with \"([^\"]*)\" subject and \"([^\"]*)\" as organizer on \"([^\"]*)\" room$")
+    public void addMeetingByAPI(String subject, String organizer, String room)
+	    throws Throwable {
+	Meeting meeting = new Meeting(organizer, subject, RMGenerator.getIsoTime(0),
+		RMGenerator.getIsoTime(1), room, room + "@cba.edu", room + "@cba.edu",
+		PropertiesReader.getExchangeInviteMail());
+	MeetingAPIManager.postRequest(room, meeting);
+    }
+
+    
+}

--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeGivenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeGivenSteps.java
@@ -12,11 +12,11 @@ public class HomeGivenSteps {
     @Given("^I have a meeting with \"([^\"]*)\" subject and \"([^\"]*)\" as organizer on \"([^\"]*)\" room$")
     public void addMeetingByAPI(String subject, String organizer, String room)
 	    throws Throwable {
-	Meeting meeting = new Meeting(organizer, subject, RMGenerator.getIsoTime(0),
-		RMGenerator.getIsoTime(1), room, room + "@cba.edu", room + "@cba.edu",
+	Meeting meeting = new Meeting(organizer, subject,
+		RMGenerator.getIsoTime(0), RMGenerator.getIsoTime(1), room,
+		room + "@" + PropertiesReader.getExchangeDomain(), 
+		room + "@" + PropertiesReader.getExchangeDomain(),
 		PropertiesReader.getExchangeInviteMail());
 	MeetingAPIManager.postRequest(room, meeting);
     }
-
-    
 }

--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeThenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeThenSteps.java
@@ -17,12 +17,7 @@ public class HomeThenSteps {
 
     @Then("^All meetings of \"([^\"]*)\" room are displayed on home time line even \"([^\"]*)\" meeting$")
     public void verifyTimeLineMeetings(String roomName, String subject) throws Throwable {
-	SchedulerPage schedulerPage = new SchedulerPage();
         HomePage homePage = new HomePage();
-        
-        schedulerPage
-        .topMenu
-        .clickOnHomeButton();
 
 	MongoClient mongoClient = new MongoClient(
 		PropertiesReader.getHostIPAddress(),

--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeWhenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/home/HomeWhenSteps.java
@@ -20,4 +20,5 @@ public class HomeWhenSteps {
 		.setPassword(PropertiesReader.getExchangeOrganizerPwd())
 		.clickOkButton();
     }
+    
 }

--- a/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/home.feature
+++ b/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/home.feature
@@ -5,12 +5,12 @@ Given I have a meeting with "TestMeeting" subject and "Ariel" as organizer on "R
 When I am on Home Page of "Room003" room
 Then All meetings of "Room003" room are displayed on home time line even "TestMeeting" meeting
 
-#Scenario: Current meeting subject  is displayed on Home Page when it is created
-#Given I am on Home Page of "Room003" room
-#When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
-#Then The meeting "TestMeeting" is displayed on Home Page as current
+Scenario: Current meeting subject  is displayed on Home Page when it is created
+Given I am on Home Page of "Room003" room
+When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
+Then The meeting "TestMeeting" is displayed on Home Page as current
 
-#Scenario: Current meeting organizer is displayed on Home Page when it  is created
-#Given I am on Home Page of "Room003" room
-#When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
-#Then The organizer "Ariel" of current meeting "TestMeeting" is displayed on Home
+Scenario: Current meeting organizer is displayed on Home Page when it  is created
+Given I am on Home Page of "Room003" room
+When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
+Then The organizer "Ariel" of current meeting "TestMeeting" is displayed on Home

--- a/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/home.feature
+++ b/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/home.feature
@@ -1,16 +1,16 @@
 Feature: Tablet Home Page
 
-#Scenario: All meetings are displayed on Home Page time line when it is opened
-#Given I am on Home Page of "Room004" room 
-#When I create a meeting with "TestMeeting" subject and "Ariel" as organizer
-#Then All meetings of "Room004" room are displayed on home time line even "TestMeeting" meeting
+Scenario: All meetings are displayed on Home Page time line when it is opened
+Given I have a meeting with "TestMeeting" subject and "Ariel" as organizer on "Room003" room
+When I am on Home Page of "Room003" room
+Then All meetings of "Room003" room are displayed on home time line even "TestMeeting" meeting
 
 #Scenario: Current meeting subject  is displayed on Home Page when it is created
-#Given I am on Home Page of "Room004" room
+#Given I am on Home Page of "Room003" room
 #When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
 #Then The meeting "TestMeeting" is displayed on Home Page as current
 
-Scenario: Current meeting subject  is displayed on Home Page when it is created
-Given I am on Home Page of "Room004" room
-When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
-Then The organizer "Ariel" of current meeting "TestMeeting" is displayed on Home
+#Scenario: Current meeting organizer is displayed on Home Page when it  is created
+#Given I am on Home Page of "Room003" room
+#When I create a meeting with "TestMeeting" subject and "Ariel" as organizer 
+#Then The organizer "Ariel" of current meeting "TestMeeting" is displayed on Home


### PR DESCRIPTION
Fix Scenario: All meetings are displayed on home page when it is opened - no hardcode
