### PR TITLE
Add Scenarios Impersonation Tablet: 

### DIFF
--- a/Projects/RMAutomationUIFramework/src/main/java/org/fundacionjala/automation/framework/maps/tablet/scheduler/CredentialsMap.java
+++ b/Projects/RMAutomationUIFramework/src/main/java/org/fundacionjala/automation/framework/maps/tablet/scheduler/CredentialsMap.java
@@ -6,7 +6,9 @@ public class CredentialsMap {
 	public static final String USER_NAME_TEXT_FIELD = "//label[text()='Username']/parent::div/descendant::input[@type='text'][@placeholder='username']";
 	public static final String PASSWORD_TEXT_FIELD = "//input[@type='password'][@ng-model='dialog.credentials.password'][@placeholder='password']";
 	public static final String OK_BUTTON = "//button[@ng-click='dialog.ok()'][@type='button']";
+	public static final String CANCEL_BUTTON = "//button[@ng-click='dialog.modalDismiss()'][@type='button']";
 	public static final String CREATE_AS_CHECKBOX = "//span[@class='checkbox-label ng-binding'][contains(text(),'Create as')]";
 	public static final String CANCEL_AS_CHECKBOX = "//span[@class='checkbox-label ng-binding'][contains(text(),'Cancel as')]";
 	public static final String CANCEL_IN_BEHALF_OF_MESSAGE = "//h4[@class='ng-binding'][contains(text(),'Cancel in behalf of')]";
+	public static final String NO_FUNCTIONALITY_PROVIDED_MESSAGE = "//h3[text()='No functionality provided yet']";
 }

--- a/Projects/RMAutomationUIFramework/src/main/java/org/fundacionjala/automation/framework/pages/tablet/scheduler/CredentialsPage.java
+++ b/Projects/RMAutomationUIFramework/src/main/java/org/fundacionjala/automation/framework/pages/tablet/scheduler/CredentialsPage.java
@@ -22,6 +22,8 @@ public class CredentialsPage {
     WebElement createAsCheckBox;
     @FindBy(xpath = CredentialsMap.OK_BUTTON)
     WebElement okButton;
+    @FindBy(xpath = CredentialsMap.CANCEL_BUTTON)
+    WebElement cancelButton;
     @FindBy (xpath = CredentialsMap.CANCEL_AS_CHECKBOX)
     WebElement cancelAsCheckBox;
 
@@ -61,6 +63,16 @@ public class CredentialsPage {
 
 	LogManager.info("Ok Button has been clicked");
 
+	return new SchedulerPage();
+    }
+    
+    public SchedulerPage clickCancelButton() {
+	(new WebDriverWait(BrowserManager.getDriver(), 30)).until(ExpectedConditions.elementToBeClickable(cancelButton));
+	cancelButton.click();
+	(new WebDriverWait(BrowserManager.getDriver(), 30)).until(ExpectedConditions.invisibilityOfElementLocated(By.xpath(CredentialsMap.CANCEL_BUTTON)));
+	
+	LogManager.info("Cancel Button has been clicked");
+	
 	return new SchedulerPage();
     }
 
@@ -116,6 +128,22 @@ public class CredentialsPage {
 	    return false;
 	}
     }
+    
+    public boolean isNoFunctionalityProvidedMessagePresent() {
+	try {
+	    (new WebDriverWait(BrowserManager.getDriver(), 15))
+		    .until(ExpectedConditions
+			    .presenceOfElementLocated(By
+				    .xpath(CredentialsMap.NO_FUNCTIONALITY_PROVIDED_MESSAGE)));
+	    LogManager.info("No functionality provided Message has been found");
+	    return true;
+
+	} catch (Exception e) {
+	    LogManager
+		    .info("No functionality provided Message has not been found");
+	    return false;
+	}
+    }
 
     public boolean isCreateAsCheckBoxPresent() {
 	try {
@@ -139,6 +167,32 @@ public class CredentialsPage {
 
 	} catch (Exception e) {
 	    LogManager.info("Cancel As CheckBox has not been found");
+	    return false;
+	}
+    }
+    
+    public boolean isUserNameTextFieldPresent() {
+	try {
+	    (new WebDriverWait(BrowserManager.getDriver(), 15))
+		    .until(ExpectedConditions.visibilityOf(userNameTextField));
+	    LogManager.info("User Name Text Field has been found");
+	    return true;
+
+	} catch (Exception e) {
+	    LogManager.info("User Name Text Field has not been found");
+	    return false;
+	}
+    }
+    
+    public boolean isPasswordTextFieldPresent() {
+	try {
+	    (new WebDriverWait(BrowserManager.getDriver(), 15))
+		    .until(ExpectedConditions.visibilityOf(userNameTextField));
+	    LogManager.info("Password Text Field has been found");
+	    return true;
+
+	} catch (Exception e) {
+	    LogManager.info("Password Text Field has not been found");
 	    return false;
 	}
     }

--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationGivenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationGivenSteps.java
@@ -1,0 +1,45 @@
+package org.fundacionjala.automation.scenario.steps.tablet.impersonation;
+
+import org.fundacionjala.automation.framework.pages.tablet.home.HomePage;
+import org.fundacionjala.automation.framework.pages.tablet.scheduler.CredentialsPage;
+import org.fundacionjala.automation.framework.pages.tablet.scheduler.SchedulerPage;
+import org.fundacionjala.automation.framework.pages.tablet.settings.ConnectionPage;
+import org.fundacionjala.automation.framework.pages.tablet.settings.NavigationPage;
+import org.fundacionjala.automation.framework.utils.common.BrowserManager;
+import org.fundacionjala.automation.framework.utils.common.PropertiesReader;
+
+import cucumber.api.java.en.Given;
+
+public class ImpersonationGivenSteps {
+    	@Given("^I schedule a new meeting with \"([^\"]*)\" subject$")
+   	public void createMeetingUsingImpersonation(String subject) throws Throwable {
+    	BrowserManager.openBrowser();
+    	ConnectionPage connection = new ConnectionPage();
+
+		NavigationPage navigation = connection
+				.setUpServiceURL(PropertiesReader.getServiceURL())
+				.clickOnSaveButton()
+				.clickOnNavigationButton();
+
+		HomePage home = navigation
+				.clickOnRoomToggleButton()
+				.selectConferenceRoom(PropertiesReader.getConferenceRoom())
+				.clickOnSaveButton()
+				.topMenu
+				.clickOnHomeButton();
+
+		SchedulerPage scheduler = home
+				.clickOnScheduleButton()
+				.setOrganizer(PropertiesReader.getExchangeOrganizerUser())
+				.setSubject(subject)
+				.setAttende(PropertiesReader.getExchangeInviteMail());
+
+		CredentialsPage credentials = scheduler
+				.clickOnCreateButton();
+		
+		scheduler = credentials
+				.setUserName(PropertiesReader.getExchangeOrganizerUser())
+				.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+				.clickOkButton();
+	}
+}

--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationThenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationThenSteps.java
@@ -2,6 +2,8 @@ package org.fundacionjala.automation.scenario.steps.tablet.impersonation;
 
 import org.fundacionjala.automation.framework.pages.tablet.scheduler.CredentialsPage;
 import org.fundacionjala.automation.framework.pages.tablet.scheduler.SchedulerPage;
+import org.fundacionjala.automation.framework.utils.api.managers.SettingsAPIManager;
+import org.fundacionjala.automation.framework.utils.api.objects.admin.Settings;
 import org.fundacionjala.automation.framework.utils.common.PropertiesReader;
 import org.testng.Assert;
 
@@ -30,7 +32,6 @@ public class ImpersonationThenSteps {
         	
         	Assert.assertEquals(actualSubject, expectedSubject);
         	Assert.assertEquals(actualOrganizer, expectedOrganizer);
-        	Assert.assertTrue(scheduler.isAttendeePresent(PropertiesReader.getExchangeOrganizerMail()));
         	Assert.assertTrue(scheduler.isAttendeePresent(PropertiesReader.getExchangeInviteMail()));
         	
         	CredentialsPage credentials = scheduler
@@ -116,6 +117,19 @@ public class ImpersonationThenSteps {
         	table.update(query, updateObj);
     	}
     	
+    	@Then("^create Impersonation Options are not displayed in the Credentials Page$")
+    	public void verifyCreateImpersonationOptionsAreNotDisplayed() throws Throwable {
+            	CredentialsPage credentials = new CredentialsPage();
+        	boolean impersonationOptionsArePresent = false;
+        
+        	if ((credentials.isCreateAsCheckBoxPresent())
+        			&& (credentials.isCreateInBehalfOfTextFieldPresent())) {
+        		impersonationOptionsArePresent = true;
+        	}
+        
+        	Assert.assertFalse(impersonationOptionsArePresent);
+    	}
+    	
     	@Then("^cancel Impersonation Options are displayed in the Credentials Page$")
     	public void verifyCancelImpersonationOptionsAreDisplayed() throws Throwable {
             	CredentialsPage credentials = new CredentialsPage();
@@ -149,5 +163,135 @@ public class ImpersonationThenSteps {
         	updateObj.put("$set", newDocument);
         
         	table.update(query, updateObj);
+    	}
+    	
+    	@Then("^cancel Impersonation Options are not displayed in the Credentials Page$")
+    	public void verifyCancelImpersonationOptionsAreNotDisplayed() throws Throwable {
+            	CredentialsPage credentials = new CredentialsPage();
+        	boolean impersonationOptionsArePresent = false;
+        
+        	if ((credentials.isCancelAsCheckBoxPresent())
+        			&& (credentials.isCancelInBehalfOfMessagePresent())) {
+        		impersonationOptionsArePresent = true;
+        	}
+        
+        	Assert.assertFalse(impersonationOptionsArePresent);
+        	
+            	credentials
+            		.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+            		.clickOkButton();
+    	}
+    	
+    	@Then("^create Credentials Authentication Options are displayed in the Credentials Page$")
+    	public void verifyCreateCredentialsAuthenticationOptionsAreDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+    	    
+    	    	Assert.assertTrue(credentials.isUserNameTextFieldPresent());
+    	    	Assert.assertTrue(credentials.isPasswordTextFieldPresent());
+    	    	Assert.assertFalse(credentials.isCreateAsCheckBoxPresent());
+    	    	Assert.assertFalse(credentials.isCreateInBehalfOfTextFieldPresent());
+    	}
+    	
+    	@Then("^create Credentials Authentication Options are not displayed in the Credentials Page$")
+    	public void verifyCreateCredentialsAuthenticationOptionsAreNotDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+    	    
+    	    	Assert.assertFalse(credentials.isUserNameTextFieldPresent());
+    	    	Assert.assertFalse(credentials.isPasswordTextFieldPresent());
+    	    	Assert.assertFalse(credentials.isCreateAsCheckBoxPresent());
+    	    	Assert.assertFalse(credentials.isCreateInBehalfOfTextFieldPresent());
+    	}
+    	
+    	@Then("^cancel Credentials Authentication Options are displayed in the Credentials Page$")
+    	public void verifyCancelCredentialsAuthenticationOptionsAreDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+	    
+	    	Assert.assertTrue(credentials.isUserNameTextFieldPresent());
+	    	Assert.assertTrue(credentials.isPasswordTextFieldPresent());
+	    	Assert.assertFalse(credentials.isCancelAsCheckBoxPresent());
+	    	Assert.assertFalse(credentials.isCancelInBehalfOfMessagePresent());
+	    	
+	    	credentials
+	    		.setUserName(PropertiesReader.getExchangeOrganizerUser())
+	    		.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+	    		.clickOkButton();
+    	}
+    	
+    	@Then("^cancel Credentials Authentication Options are not displayed in the Credentials Page$")
+    	public void verifyCancelCredentialsAuthenticationOptionsAreNotDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+	    
+	    	Assert.assertFalse(credentials.isUserNameTextFieldPresent());
+	    	Assert.assertFalse(credentials.isPasswordTextFieldPresent());
+	    	Assert.assertFalse(credentials.isCancelAsCheckBoxPresent());
+	    	Assert.assertFalse(credentials.isCancelInBehalfOfMessagePresent());
+	    	
+	    	Settings settings = new Settings(PropertiesReader
+	    		.getCredentialsAuthenticationType(), 5, "blue");
+		SettingsAPIManager.putRequest(PropertiesReader.getServiceURL()
+				+ "/settings", settings);
+		
+		SchedulerPage scheduler = credentials
+						.clickCancelButton();
+		
+		credentials = scheduler
+				.clickRemoveButton();
+		
+		credentials
+			.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+			.clickOkButton();
+    	}
+    	
+    	@Then("^create RFID Authentication Options are displayed in the Credentials Page$")
+    	public void verifyCreateRFIDAuthenticationOptionsAreDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+    	    	
+    	    	Assert.assertTrue(credentials.isNoFunctionalityProvidedMessagePresent());
+    	    	
+    	    	Settings settings = new Settings(PropertiesReader
+    	    		.getCredentialsAuthenticationType(), 5, "blue");
+		SettingsAPIManager.putRequest(PropertiesReader.getServiceURL()
+				+ "/settings", settings);
+    	}
+    	
+    	@Then("^create RFID Authentication Options are not displayed in the Credentials Page$")
+    	public void verifyCreateRFIDAuthenticationOptionsAreNotDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+    	    	
+    	    	Assert.assertFalse(credentials.isNoFunctionalityProvidedMessagePresent());
+    	}
+    	
+    	@Then("^cancel RFID Authentication Options are displayed in the Credentials Page$")
+    	public void verifyCancelRFIDAuthenticationOptionsAreDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+    	    	
+    	    	Assert.assertTrue(credentials.isNoFunctionalityProvidedMessagePresent());
+	    	
+	    	Settings settings = new Settings(PropertiesReader
+	    		.getCredentialsAuthenticationType(), 5, "blue");
+		SettingsAPIManager.putRequest(PropertiesReader.getServiceURL()
+				+ "/settings", settings);
+		
+		SchedulerPage scheduler = credentials
+						.clickCancelButton();
+		
+		credentials = scheduler
+				.clickRemoveButton();
+		
+		credentials
+			.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+			.clickOkButton();
+    	}
+    	
+    	@Then("^cancel RFID Authentication Options are not displayed in the Credentials Page$")
+    	public void verifyCancelRFIDAuthenticationOptionsAreNotDisplayed() throws Throwable {
+    	    	CredentialsPage credentials = new CredentialsPage();
+    	    	
+    	    	Assert.assertFalse(credentials.isNoFunctionalityProvidedMessagePresent());
+	    	
+            	credentials
+            		.setUserName(PropertiesReader.getExchangeOrganizerUser())
+        		.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+        		.clickOkButton();
     	}
 }

--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationWhenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationWhenSteps.java
@@ -45,7 +45,6 @@ public class ImpersonationWhenSteps {
    				.clickOkButton();
    	}
     
-    
     	@When("^I cancel a meeting with \"([^\"]*)\" subject using Impersonation$")
     	public void cancelMeetingUsingImpersonation(String subject) throws Throwable {	
 		BrowserManager.openBrowser();
@@ -127,4 +126,87 @@ public class ImpersonationWhenSteps {
         		.clickOnMeetingButton(subject)
         		.clickRemoveButton();
     	}
+    	
+    	@When("^I try to create a new meeting with \"([^\"]*)\" subject$")
+    	public void tryToCreateMeeting(String subject) throws Throwable {
+    	    	BrowserManager.openBrowser();
+        	ConnectionPage connection = new ConnectionPage();
+    
+        	NavigationPage navigation = connection
+    				.setUpServiceURL(PropertiesReader.getServiceURL())
+    				.clickOnSaveButton()
+    				.clickOnNavigationButton();
+    
+        	HomePage home = navigation
+    				.clickOnRoomToggleButton()
+    				.selectConferenceRoom(PropertiesReader.getConferenceRoom())
+    				.clickOnSaveButton()
+    				.topMenu
+    				.clickOnHomeButton();
+    
+        	SchedulerPage scheduler = home.clickOnScheduleButton()
+    				.setOrganizer(PropertiesReader.getExchangeConnectUserName())
+    				.setSubject(subject)
+    				.setAttende(PropertiesReader.getExchangeInviteMail());
+    
+        	scheduler
+        		.clickOnCreateButton();
+    	}
+    	
+    	@When("^I try to cancel a meeting with \"([^\"]*)\" subject$")
+    	public void tryToCancelMeeting(String subject) throws Throwable {
+            	BrowserManager.openBrowser();
+        	ConnectionPage connection = new ConnectionPage();
+        
+        	NavigationPage navigation = connection
+        			.setUpServiceURL(PropertiesReader.getServiceURL())
+        			.clickOnSaveButton()
+        			.clickOnNavigationButton();
+        
+        	HomePage home = navigation
+        			.clickOnRoomToggleButton()
+        			.selectConferenceRoom(PropertiesReader.getConferenceRoom())
+        			.clickOnSaveButton()
+        			.topMenu
+        			.clickOnHomeButton();
+        	
+        	SchedulerPage scheduler = home
+        			.clickOnScheduleButton();
+        	
+        	scheduler
+        		.clickOnMeetingButton(subject)
+        		.clickRemoveButton();
+    	}
+    	
+    	@When("^I schedule a new meeting with \"([^\"]*)\" subject$")
+   	public void createMeeting(String subject) throws Throwable {
+        	BrowserManager.openBrowser();
+        	ConnectionPage connection = new ConnectionPage();
+
+   		NavigationPage navigation = connection
+   				.setUpServiceURL(PropertiesReader.getServiceURL())
+   				.clickOnSaveButton()
+   				.clickOnNavigationButton();
+
+   		HomePage home = navigation
+   				.clickOnRoomToggleButton()
+   				.selectConferenceRoom(PropertiesReader.getConferenceRoom())
+   				.clickOnSaveButton()
+   				.topMenu
+   				.clickOnHomeButton();
+
+   		SchedulerPage scheduler = home
+   				.clickOnScheduleButton()
+   				.setOrganizer(PropertiesReader.getExchangeOrganizerUser())
+   				.setSubject(subject)
+   				.setAttende(PropertiesReader.getExchangeInviteMail());
+
+   		CredentialsPage credentials = scheduler
+   				.clickOnCreateButton();
+   		
+   		scheduler = credentials
+   				.setUserName(PropertiesReader.getExchangeOrganizerUser())
+   				.setPassword(PropertiesReader.getExchangeOrganizerPwd())
+   				.clickOkButton();
+   	}
 }

--- a/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/impersonation.feature
+++ b/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/impersonation.feature
@@ -4,26 +4,92 @@ Scenario: A meeting is scheduled using Impersonation
 Given impersonation is enabled
 And authentication type configured as "credentials"
 When I schedule a new meeting with "Subject" subject using Impersonation
-Then A meeting with "My Subject" subject is created
+Then A meeting with "Subject" subject is created
 
 Scenario: A meeting is cancelled using Impersonation
 Given impersonation is enabled
 And authentication type configured as "credentials"
-And I schedule a new meeting with "Subject" subject using Impersonation
-When I cancel a meeting with "Subject" subject using Impersonation
-Then A meeting with "My Subject" subject is removed
+And I schedule a new meeting with "My Test Subject" subject using Impersonation
+When I cancel a meeting with "My Test Subject" subject using Impersonation
+Then A meeting with "My Test Subject" subject is removed
 
 Scenario: Impersonation Options are displayed in the Credentials Page 
 when creating a Meeting
 Given impersonation is enabled
 And authentication type configured as "credentials"
-When I try to create a new meeting with "My Subject" subject using Impersonation
+When I try to create a new meeting with "New Subject" subject using Impersonation
 Then create Impersonation Options are displayed in the Credentials Page
 
 Scenario: Impersonation Options are displayed in the Credentials Page
 when removing a Meeting
 Given impersonation is enabled
 And authentication type configured as "credentials"
-And I schedule a new meeting with "Subject" subject using Impersonation
-When I try to cancel a meeting with "Subject" subject using Impersonation
+And I schedule a new meeting with "Another Subject" subject using Impersonation
+When I try to cancel a meeting with "Another Subject" subject using Impersonation
 Then cancel Impersonation Options are displayed in the Credentials Page
+
+Scenario: Impersonation Options are not displayed in the Credentials Page 
+when creating a Meeting with Impersonation disabled
+Given impersonation is disabled
+And authentication type configured as "credentials"
+When I try to create a new meeting with "New Subject" subject
+Then create Impersonation Options are not displayed in the Credentials Page
+
+Scenario: Impersonation Options are not displayed in the Credentials Page
+when removing a Meeting with Impersonation disabled
+Given impersonation is disabled
+And authentication type configured as "credentials"
+And I schedule a new meeting with "Another Subject" subject
+When I try to cancel a meeting with "Another Subject" subject
+Then cancel Impersonation Options are not displayed in the Credentials Page
+
+Scenario: Credentials Authentication Options are displayed in the Credentials
+Page when creating a Meeting
+Given authentication type configured as "credentials"
+When I try to create a new meeting with "My Subject" subject
+Then create Credentials Authentication Options are displayed in the Credentials Page
+
+Scenario: Credentials Authentication Options are displayed in the Credentials
+Page when removing a Meeting
+Given authentication type configured as "credentials"
+When I schedule a new meeting with "Subject" subject
+Then cancel Credentials Authentication Options are displayed in the Credentials Page
+
+Scenario: Credentials Authentication Options are not displayed in the Credentials
+Page when creating a Meeting with Credentials authentication disabled
+Given authentication type configured as "rfid"
+When I try to create a new meeting with "My Subject" subject
+Then create Credentials Authentication Options are not displayed in the Credentials Page
+
+Scenario: Credentials Authentication Options are not displayed in the Credentials
+Page when removing a Meeting with Credentials authentication disabled
+Given authentication type configured as "credentials"
+And I schedule a new meeting with "Subject" subject
+When authentication type configured as "rfid"
+Then cancel Credentials Authentication Options are not displayed in the Credentials Page
+
+Scenario: Credentials RFID Options are displayed in the Credentials
+Page when creating a Meeting
+Given authentication type configured as "rfid"
+When I try to create a new meeting with "My Subject" subject
+Then create RFID Authentication Options are displayed in the Credentials Page
+
+Scenario: Credentials RFID Options are displayed in the Credentials
+Page when removing a Meeting
+Given I schedule a new meeting with "Custom Subject" subject
+And authentication type configured as "rfid"
+When I try to cancel a meeting with "Custom Subject" subject
+Then cancel RFID Authentication Options are displayed in the Credentials Page
+
+Scenario: Credentials RFID Options are not displayed in the Credentials
+Page when creating a Meeting with RFID authentication disabled
+Given authentication type configured as "credentials"
+When I try to create a new meeting with "My Subject" subject
+Then create RFID Authentication Options are not displayed in the Credentials Page
+
+Scenario: Credentials RFID Options are not displayed in the Credentials
+Page when removing a Meeting with RFID authentication disabled
+Given authentication type configured as "credentials"
+And I schedule a new meeting with "My new Subject" subject
+When I try to cancel a meeting with "My new Subject" subject
+Then cancel RFID Authentication Options are not displayed in the Credentials Page


### PR DESCRIPTION
Add Scenarios Impersonation Tablet: Impersonation Options are not displayed in the Credentials Page when creating a Meeting with Impersonation disabled, Impersonation Options are not displayed in the Credentials Page when removing a Meeting with Impersonation disabled, Credentials Authentication Options are displayed in the Credentials Page when creating a Meeting, Credentials Authentication Options are displayed in the Credentials Page when removing a Meeting, Credentials Authentication Options are not displayed in the Credentials Page when creating a Meeting with Credentials authentication disabled, Credentials Authentication Options are not displayed in the Credentials Page when removing a Meeting with Credentials authentication disabled, Credentials RFID Options are displayed in the Credentials Page when creating a Meeting, Credentials RFID Options are displayed in the Credentials Page when removing a Meeting, Credentials RFID Options are not displayed in the Credentials Page when creating a Meeting with RFID authentication disabled and Credentials RFID Options are not displayed in the Credentials Page when removing a Meeting with RFID authentication disabled Scenarios Implemented.
