### PR TITLE
Fix Impersonation Scenarios

### DIFF
--- a/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationThenSteps.java
+++ b/Projects/RMAutomationUIFramework/src/test/java/org/fundacionjala/automation/scenario/steps/tablet/impersonation/ImpersonationThenSteps.java
@@ -200,11 +200,20 @@ public class ImpersonationThenSteps {
     	    	Assert.assertFalse(credentials.isPasswordTextFieldPresent());
     	    	Assert.assertFalse(credentials.isCreateAsCheckBoxPresent());
     	    	Assert.assertFalse(credentials.isCreateInBehalfOfTextFieldPresent());
+    	    	
+    	    	Settings settings = new Settings(PropertiesReader
+	    		.getCredentialsAuthenticationType(), 5, "blue");
+		SettingsAPIManager.putRequest(PropertiesReader.getServiceURL()
+				+ "/settings", settings);
     	}
     	
-    	@Then("^cancel Credentials Authentication Options are displayed in the Credentials Page$")
-    	public void verifyCancelCredentialsAuthenticationOptionsAreDisplayed() throws Throwable {
-    	    	CredentialsPage credentials = new CredentialsPage();
+    	@Then("^cancel Credentials Authentication Options are displayed in the Credentials Page when cancelling \"([^\"]*)\" meeting$")
+    	public void verifyCancelCredentialsAuthenticationOptionsAreDisplayed(String subject) throws Throwable {
+    	    	SchedulerPage scheduler = new SchedulerPage();
+    	    	
+    	    	CredentialsPage credentials = scheduler
+				.clickOnMeeting(subject)
+				.clickOnRemoveButton();
 	    
 	    	Assert.assertTrue(credentials.isUserNameTextFieldPresent());
 	    	Assert.assertTrue(credentials.isPasswordTextFieldPresent());
@@ -212,14 +221,17 @@ public class ImpersonationThenSteps {
 	    	Assert.assertFalse(credentials.isCancelInBehalfOfMessagePresent());
 	    	
 	    	credentials
-	    		.setUserName(PropertiesReader.getExchangeOrganizerUser())
 	    		.setPassword(PropertiesReader.getExchangeOrganizerPwd())
 	    		.clickOkButton();
     	}
     	
-    	@Then("^cancel Credentials Authentication Options are not displayed in the Credentials Page$")
-    	public void verifyCancelCredentialsAuthenticationOptionsAreNotDisplayed() throws Throwable {
-    	    	CredentialsPage credentials = new CredentialsPage();
+    	@Then("^cancel Credentials Authentication Options are not displayed in the Credentials Page when cancelling \"([^\"]*)\" meeting$")
+    	public void verifyCancelCredentialsAuthenticationOptionsAreNotDisplayed(String subject) throws Throwable {
+    	    	SchedulerPage scheduler = new SchedulerPage();
+    	    
+    	    	CredentialsPage credentials = scheduler
+    	    					.clickOnMeeting(subject)
+    	    					.clickOnRemoveButton();
 	    
 	    	Assert.assertFalse(credentials.isUserNameTextFieldPresent());
 	    	Assert.assertFalse(credentials.isPasswordTextFieldPresent());
@@ -231,8 +243,8 @@ public class ImpersonationThenSteps {
 		SettingsAPIManager.putRequest(PropertiesReader.getServiceURL()
 				+ "/settings", settings);
 		
-		SchedulerPage scheduler = credentials
-						.clickCancelButton();
+		scheduler = credentials
+				.clickCancelButton();
 		
 		credentials = scheduler
 				.clickRemoveButton();
@@ -290,7 +302,6 @@ public class ImpersonationThenSteps {
     	    	Assert.assertFalse(credentials.isNoFunctionalityProvidedMessagePresent());
 	    	
             	credentials
-            		.setUserName(PropertiesReader.getExchangeOrganizerUser())
         		.setPassword(PropertiesReader.getExchangeOrganizerPwd())
         		.clickOkButton();
     	}

--- a/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/impersonation.feature
+++ b/Projects/RMAutomationUIFramework/src/test/resources/features/tablet/impersonation.feature
@@ -28,45 +28,39 @@ And I schedule a new meeting with "Another Subject" subject using Impersonation
 When I try to cancel a meeting with "Another Subject" subject using Impersonation
 Then cancel Impersonation Options are displayed in the Credentials Page
 
-Scenario: Impersonation Options are not displayed in the Credentials Page 
-when creating a Meeting with Impersonation disabled
+Scenario: Impersonation Options are not displayed in the Credentials Page when creating a Meeting with Impersonation disabled
 Given impersonation is disabled
 And authentication type configured as "credentials"
 When I try to create a new meeting with "New Subject" subject
 Then create Impersonation Options are not displayed in the Credentials Page
 
-Scenario: Impersonation Options are not displayed in the Credentials Page
-when removing a Meeting with Impersonation disabled
+Scenario: Impersonation Options are not displayed in the Credentials Page when removing a Meeting with Impersonation disabled
 Given impersonation is disabled
 And authentication type configured as "credentials"
 And I schedule a new meeting with "Another Subject" subject
 When I try to cancel a meeting with "Another Subject" subject
 Then cancel Impersonation Options are not displayed in the Credentials Page
 
-Scenario: Credentials Authentication Options are displayed in the Credentials
-Page when creating a Meeting
+Scenario: Credentials Authentication Options are displayed in the Credentials Page when creating a Meeting
 Given authentication type configured as "credentials"
 When I try to create a new meeting with "My Subject" subject
 Then create Credentials Authentication Options are displayed in the Credentials Page
 
-Scenario: Credentials Authentication Options are displayed in the Credentials
-Page when removing a Meeting
+Scenario: Credentials Authentication Options are displayed in the Credentials Page when removing a Meeting
 Given authentication type configured as "credentials"
 When I schedule a new meeting with "Subject" subject
-Then cancel Credentials Authentication Options are displayed in the Credentials Page
+Then cancel Credentials Authentication Options are displayed in the Credentials Page when cancelling "Subject" meeting
 
-Scenario: Credentials Authentication Options are not displayed in the Credentials
-Page when creating a Meeting with Credentials authentication disabled
+Scenario: Credentials Authentication Options are not displayed in the Credentials Page when creating a Meeting with Credentials authentication disabled
 Given authentication type configured as "rfid"
 When I try to create a new meeting with "My Subject" subject
 Then create Credentials Authentication Options are not displayed in the Credentials Page
 
-Scenario: Credentials Authentication Options are not displayed in the Credentials
-Page when removing a Meeting with Credentials authentication disabled
+Scenario: Credentials Authentication Options are not displayed in the Credentials Page when removing a Meeting with Credentials authentication disabled
 Given authentication type configured as "credentials"
 And I schedule a new meeting with "Subject" subject
 When authentication type configured as "rfid"
-Then cancel Credentials Authentication Options are not displayed in the Credentials Page
+Then cancel Credentials Authentication Options are not displayed in the Credentials Page when cancelling "Subject" meeting
 
 Scenario: Credentials RFID Options are displayed in the Credentials
 Page when creating a Meeting
@@ -74,21 +68,18 @@ Given authentication type configured as "rfid"
 When I try to create a new meeting with "My Subject" subject
 Then create RFID Authentication Options are displayed in the Credentials Page
 
-Scenario: Credentials RFID Options are displayed in the Credentials
-Page when removing a Meeting
+Scenario: Credentials RFID Options are displayed in the Credentials Page when removing a Meeting
 Given I schedule a new meeting with a "Custom Subject" subject
 And authentication type configured as "rfid"
 When I try to cancel a meeting with "Custom Subject" subject
 Then cancel RFID Authentication Options are displayed in the Credentials Page
 
-Scenario: Credentials RFID Options are not displayed in the Credentials
-Page when creating a Meeting with RFID authentication disabled
+Scenario: Credentials RFID Options are not displayed in the Credentials Page when creating a Meeting with RFID authentication disabled
 Given authentication type configured as "credentials"
 When I try to create a new meeting with "My Subject" subject
 Then create RFID Authentication Options are not displayed in the Credentials Page
 
-Scenario: Credentials RFID Options are not displayed in the Credentials
-Page when removing a Meeting with RFID authentication disabled
+Scenario: Credentials RFID Options are not displayed in the Credentials Page when removing a Meeting with RFID authentication disabled
 Given authentication type configured as "credentials"
 And I schedule a new meeting with "My new Subject" subject
 When I try to cancel a meeting with "My new Subject" subject


### PR DESCRIPTION
Fix Impersonation Scenarios:
- Impersonation Options are not displayed in the Credentials Page when creating a Meeting with Impersonation disabled.
- Impersonation Options are not displayed in the Credentials Page when removing a Meeting with Impersonation disabled.
- Credentials Authentication Options are displayed in the Credentials Page when creating a Meeting.
- Credentials Authentication Options are displayed in the Credentials Page when removing a Meeting.
- Credentials Authentication Options are not displayed in the Credentials Page when creating a Meeting with Credentials authentication disabled.
- Credentials Authentication Options are not displayed in the Credentials Page when removing a Meeting with Credentials authentication disabled.
- Credentials RFID Options are displayed in the Credentials.
- Credentials RFID Options are displayed in the Credentials Page when removing a Meeting.
- Credentials RFID Options are not displayed in the Credentials Page when creating a Meeting with RFID authentication disabled.
- Credentials RFID Options are not displayed in the Credentials Page when removing a Meeting with RFID authentication disabled.
